### PR TITLE
Use a custom agent for the connection management

### DIFF
--- a/build/api/index.js
+++ b/build/api/index.js
@@ -228,8 +228,10 @@ var API = /** @class */ (function () {
     API.prototype._get = function (path, options) {
         if (options === void 0) { options = {}; }
         global_1.Global.log("get(\"" + path + "\")", "debug");
+        // normalize path
+        path = this.getRequestPath(path);
         var reqOpts = Object.assign(options, {
-            uri: this.getRequestPath(path),
+            uri: path,
             agent: getAgent(path),
         });
         return retry(function () { return request(reqOpts); });
@@ -243,8 +245,10 @@ var API = /** @class */ (function () {
     API.prototype.getWithDigestAuth = function (path, credentials, options) {
         if (options === void 0) { options = {}; }
         global_1.Global.log("getWithDigestAuth(\"" + path + "\")", "debug");
+        // normalize path
+        path = this.getRequestPath(path);
         var reqOpts = Object.assign(options, {
-            uri: this.getRequestPath(path),
+            uri: path,
             agent: getAgent(path),
             auth: {
                 username: credentials.username,
@@ -258,8 +262,10 @@ var API = /** @class */ (function () {
     API.prototype.postJSONwithDigestAuth = function (path, credentials, jsonPayload, options) {
         if (options === void 0) { options = {}; }
         global_1.Global.log("postJSONwithDigestAuth(\"" + path + "\", " + JSON.stringify(jsonPayload) + ")", "debug");
+        // normalize path
+        path = this.getRequestPath(path);
         var reqOpts = Object.assign(options, {
-            uri: this.getRequestPath(path),
+            uri: path,
             agent: getAgent(path),
             method: "POST",
             json: jsonPayload,
@@ -275,8 +281,10 @@ var API = /** @class */ (function () {
     API.prototype.postJSON = function (path, jsonPayload, options) {
         if (options === void 0) { options = {}; }
         global_1.Global.log("postJSON(\"" + path + "\", " + JSON.stringify(jsonPayload) + ")", "debug");
+        // normalize path
+        path = this.getRequestPath(path);
         var reqOpts = Object.assign(options, {
-            uri: this.getRequestPath(path),
+            uri: path,
             agent: getAgent(path),
             method: "POST",
             json: jsonPayload,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -179,8 +179,10 @@ export abstract class API {
 	/** Performs a GET request on the given resource and returns the result */
 	private _get(path: string, options: RequestOptions = {}): Promise<string | FullResponse> {
 		_.log(`get("${path}")`, "debug");
+		// normalize path
+		path = this.getRequestPath(path);
 		const reqOpts: OptionsWithUri = Object.assign(options, {
-			uri: this.getRequestPath(path),
+			uri: path,
 			agent: getAgent(path),
 		});
 		return retry(() => request(reqOpts) as any as Promise<string | FullResponse>);
@@ -194,8 +196,10 @@ export abstract class API {
 	/** Performs a GET request on the given resource and returns the result */
 	public getWithDigestAuth(path: string, credentials: Credentials, options: RequestOptions = {}): Promise<string | FullResponse> {
 		_.log(`getWithDigestAuth("${path}")`, "debug");
+		// normalize path
+		path = this.getRequestPath(path);
 		const reqOpts: OptionsWithUri = Object.assign(options, {
-			uri: this.getRequestPath(path),
+			uri: path,
 			agent: getAgent(path),
 			auth: {
 				username: credentials.username,
@@ -209,8 +213,10 @@ export abstract class API {
 	/** Posts JSON data to the given resource and returns the result */
 	public postJSONwithDigestAuth(path: string, credentials: Credentials, jsonPayload: any, options: RequestOptions = {}): Promise<string> {
 		_.log(`postJSONwithDigestAuth("${path}", ${JSON.stringify(jsonPayload)})`, "debug");
+		// normalize path
+		path = this.getRequestPath(path);
 		const reqOpts: OptionsWithUri = Object.assign(options, {
-			uri: this.getRequestPath(path),
+			uri: path,
 			agent: getAgent(path),
 			method: "POST",
 			json: jsonPayload,
@@ -226,8 +232,10 @@ export abstract class API {
 	/** Posts JSON data to the given resource and returns the result */
 	public postJSON(path: string, jsonPayload: any, options: RequestOptions = {}): Promise<string> {
 		_.log(`postJSON("${path}", ${JSON.stringify(jsonPayload)})`, "debug");
+		// normalize path
+		path = this.getRequestPath(path);
 		const reqOpts: OptionsWithUri = Object.assign(options, {
-			uri: this.getRequestPath(path),
+			uri: path,
 			agent: getAgent(path),
 			method: "POST",
 			json: jsonPayload,


### PR DESCRIPTION
By doing so, we can force a single socket to be reused, which should get rid of the ESOCKETTIMEDOUT errors